### PR TITLE
Add .editorconfig for easier multi-developer collaboration

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+# EditorConfig is awesome: http://EditorConfig.org
+root = true
+
+[*]
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+
+[*.md]
+indent_style = tab


### PR DESCRIPTION
This PR sets some defaults for editors using the `.editorconfig` syntax. Rules were based on what I could derive from the existing code.

See http://editorconfig.org for the low-down on the file format.
